### PR TITLE
Declare input variable to avoid warning

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,3 +3,7 @@ description: 'Create checklist and complete it'
 runs:
   using: 'node12'
   main: 'dist/index.js'
+inputs:
+  gh-token:
+    description: 'GitHub token to checkout the repository'
+    required: true


### PR DESCRIPTION
Testing the dependencies upgrade and took the opportunity to solve this warning:
> Unexpected input(s) 'gh-token', valid inputs are ['']

Before:
![image](https://user-images.githubusercontent.com/19894/109256660-92c18080-784a-11eb-842c-706e9f663276.png)

After:
![image](https://user-images.githubusercontent.com/19894/109256682-a240c980-784a-11eb-93c9-27e35b4ba15c.png)
